### PR TITLE
Change SWM logo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,6 @@ mix test
 
 Copyright 2018, [Software Mansion](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=docker-elixir-fdk-aac)
 
-[![Software Mansion](https://membraneframework.github.io/static/logo/swm_logo_readme.png)](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=docker-elixir-fdk-aac)
+[![Software Mansion](https://logo.swmansion.com/logo?color=white&variant=desktop&width=200&tag=membrane-github)](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=docker-elixir-fdk-aac)
 
 Licensed under the [Apache License, Version 2.0](LICENSE)


### PR DESCRIPTION
<sup>proudly automated with <a href="https://github.com/membraneframework/sebex">Sebex</a></sup>